### PR TITLE
Automatically trust ROOT CA cert in macOS keychain

### DIFF
--- a/src/system.ts
+++ b/src/system.ts
@@ -61,7 +61,7 @@ export async function ensureCACertificate(): Promise<
     });
     writeFileSync(certPath, cert, { encoding: "utf-8" });
     writeFileSync(keyPath, key, { encoding: "utf-8" });
-    // TODO: Trust the generated Certs
+    execSync(`security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ${certPath}`);
     return { key, cert };
   }
   // LOL absolutely not.


### PR DESCRIPTION
Related to #2

Implements automatic trust of the ROOT CA certificate in the macOS keychain upon creation.

- Adds a command using `execSync` to trust the newly generated ROOT CA certificate in the macOS keychain with `security add-trusted-cert`.
- Removes the placeholder comment indicating the need to trust the generated certificates, as this functionality is now implemented.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nickhudkins/malcolm/issues/2?shareId=316426dc-9be8-4ded-931e-c9b0c39b73c3).