### PR TITLE
📦 Fix the repo url in package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - mainline
   pull_request:
 
 jobs:

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -19,6 +19,7 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           provenance: true
+          package: "packages/proxy"
 permissions:
   contents: write
   id-token: write

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.1",
   "description": "A Man-In-The-Middle Proxy for Development!",
   "repository": {
-    "url": "https://github.com/nickhudkins/malcolm"
+    "url": "git+https://github.com/nickhudkins/malcolm.git"
   },
   "workspaces": [
     "packages/*",


### PR DESCRIPTION
I guess to maybe fix this? [Run](https://github.com/nickhudkins/malcolm/actions/runs/9200646315/job/25307549942)

```
Run JS-DevTools/npm-publish@v3
Error: NpmCallError: Call to "npm publish" exited with non-zero exit code 1
npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm WARN publish errors corrected:
npm WARN publish "repository.url" was normalized to "git+https://github.com/nickhudkins/malcolm.git"
npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access
npm ERR! code EUSAGE
npm ERR! Can't generate provenance for new or private package, you must set `access` to public.

```

ps maybe fix publishing too 🤞 