### PR TITLE
🔩 Read version moar better

### DIFF
--- a/packages/proxy/src/cli.ts
+++ b/packages/proxy/src/cli.ts
@@ -1,14 +1,19 @@
 #!/usr/bin/env node
 import yargs from "yargs";
+import { promises as fs } from "node:fs";
+import path from "node:path";
 import { hideBin } from "yargs/helpers";
-import { version } from "../package.json";
 
 import { DEFAULT_PROXY_PORT, DEFAULT_PROXY_CONFIG_PATH, ENV_VAR_PREFIX, USAGE_BANNER } from "./constants.js";
 import { program } from "./program.js";
 
+// read the version from package.json
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const packageJson = JSON.parse(await fs.readFile(`${__dirname}/../package.json`, "utf-8"));
+
 const { proxyPort, userConfigPath } = await yargs(hideBin(process.argv))
   .scriptName("malcolm")
-  .version(version)
+  .version(packageJson.version)
   .options({
     proxyPort: {
       alias: ["p", "proxy-port"],


### PR DESCRIPTION
this is to fix this
```
hacksore@eloy:~/code/opensource/malcolm-demo 
master ✗ $ pnpm proxy                         

> malcolm-demo@0.0.0 proxy /Users/hacksore/code/opensource/malcolm-demo
> malcolm

(node:93553) ExperimentalWarning: Importing JSON modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
file:///Users/hacksore/code/opensource/malcolm/packages/proxy/dist/cli.js:4
import { version } from "../package.json" assert { type: 'json' };
         ^^^^^^^
SyntaxError: The requested module '../package.json' does not provide an export named 'version'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:134:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:217:5)
    at async ModuleLoader.import (node:internal/modules/esm/loader:323:24)
    at async loadESM (node:internal/process/esm_loader:28:7)
    at async handleMainPromise (node:internal/modules/run_main:113:12)
```