### PR TITLE
❌ Delete the cert on server stop

### DIFF
--- a/packages/proxy/src/constants.ts
+++ b/packages/proxy/src/constants.ts
@@ -11,6 +11,8 @@ export const DEFAULT_PROXY_CONFIG_PATH = "proxy.config.ts";
 export const DEFAULT_CERT_PATH = join(DEFAULT_CONFIG_DIR, "malcom-cert.pem");
 export const DEFAULT_KEY_PATH = join(DEFAULT_CONFIG_DIR, "malcolm-key.pem");
 
+export const DEFAULT_CERT_COMMON_NAME = "Malcolm Cert";
+
 export const DEFAULT_PROXY_PORT = 6969;
 
 export const LOG_PREFIX = "[" + chalk.yellow("👴🏻 Malcolm") + "]";

--- a/packages/proxy/src/program.ts
+++ b/packages/proxy/src/program.ts
@@ -3,7 +3,7 @@ import { getProxyConfig } from "./config.js";
 import { createFileWatcher } from "./utils.js";
 import { create } from "./proxy.js";
 import path from "path";
-import { unsetProxy } from "./system.js";
+import { unsetProxy, removeCACertificate } from "./system.js";
 
 interface ProgramOptions {
   proxyPort: number;
@@ -36,7 +36,8 @@ export async function program(opts: ProgramOptions) {
       // stop file watching
       await stopWatching();
 
-      // TODO: maybe untrust the cert?
+      // remove the CA cert
+      removeCACertificate();
 
       process.exit(0);
     });


### PR DESCRIPTION
Just delete the cert from the keychain on server stop.

I had to test like this because running via turbo/tsx is fucking with stdin and hanging on waiting for a sudo pw.

```
cd packages/proxy
npm run build && dist/cli.js
```