### PR TITLE
📰 add winston to enable improved logging (#27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Run `malcolm`
 1. Create a `proxy.config.ts` in the `packages/proxy` directory
 1. `npm run i`
 1. `npm run build`
-1. `npm run start:dev`
+1. `npm run start:dev -w packages/proxy`
+    - Note: Malcom should not be run with turbo due to STDIO issues where an input prompt is not provided within the execution content
 
 ❤️ Made with Love by @nickhudkins

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,24 @@
       "version": "7.0.1",
       "license": "MIT"
     },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+      "dependencies": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.20.2",
       "cpu": [
@@ -544,6 +562,11 @@
       "dependencies": {
         "undici-types": "~5.26.4"
       }
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",
@@ -1089,7 +1112,8 @@
     },
     "node_modules/chalk": {
       "version": "5.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -1156,6 +1180,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "license": "MIT",
@@ -1169,6 +1202,37 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/colorspace": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+      "dependencies": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
+      }
     },
     "node_modules/common-tags": {
       "version": "1.8.2",
@@ -1483,6 +1547,11 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -1982,6 +2051,11 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -2080,6 +2154,11 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -2502,6 +2581,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2630,6 +2714,11 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -2678,6 +2767,22 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "node_modules/logform": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
+      "integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
     },
     "node_modules/loupe": {
       "version": "2.3.7",
@@ -3081,6 +3186,14 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "dependencies": {
+        "fn.name": "1.x.x"
       }
     },
     "node_modules/onetime": {
@@ -3637,6 +3750,14 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "license": "MIT"
@@ -3784,6 +3905,14 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -3854,6 +3983,14 @@
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -3956,6 +4093,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -4002,6 +4144,14 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "license": "MIT"
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
     },
     "node_modules/ts-api-utils": {
       "version": "1.3.0",
@@ -4438,6 +4588,82 @@
         "node": ">=8"
       }
     },
+    "node_modules/winston": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.13.0.tgz",
+      "integrity": "sha512-rwidmA1w3SE4j0E5MuIufFhyJPBDG7Nu71RkZor1p2+qHvJSZ9GYDA81AyleQcZbh/+V6HjeBdfnTZJm9rSeQQ==",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.4.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.7.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.7.0.tgz",
+      "integrity": "sha512-ajBj65K5I7denzer2IYW6+2bNIVqLGDHqDw3Ow8Ohh+vdW+rv4MZ6eiDvHoKhfJFZ2auyN8byXieDDJ96ViONg==",
+      "dependencies": {
+        "logform": "^2.3.2",
+        "readable-stream": "^3.6.0",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/winston/node_modules/async": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
+    },
+    "node_modules/winston/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/winston/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/wmic": {
       "version": "1.1.1",
       "license": "MIT",
@@ -4596,6 +4822,7 @@
         "mockttp": "^3.10.2",
         "network": "^0.7.0",
         "tsx": "^4.11.0",
+        "winston": "^3.13.0",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -4618,6 +4845,22 @@
     "tooling/config-tsconfig": {
       "version": "1.0.0",
       "license": "ISC"
+    },
+    "tooling/logger": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "pino": "^9.1.0"
+      },
+      "devDependencies": {
+        "@types/pino": "^7.0.5",
+        "@types/pino-pretty": "^5.0.0",
+        "config-eslint": "*",
+        "config-tsconfig": "*",
+        "pino-pretty": "^11.1.0"
+      }
     }
   }
 }

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -46,6 +46,7 @@
     "mockttp": "^3.10.2",
     "network": "^0.7.0",
     "tsx": "^4.11.0",
+    "winston": "^3.13.0",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/packages/proxy/src/logger.ts
+++ b/packages/proxy/src/logger.ts
@@ -1,0 +1,21 @@
+import * as winston from "winston";
+
+export const Logger = (function () {
+  let instance: winston.Logger;
+
+  return {
+    getLogger: function () {
+      if (!instance) {
+        instance = winston.createLogger({
+          format: winston.format.json(),
+          transports: [
+            // TODO: Consider file transport for logging network activity
+            new winston.transports.Console({ format: winston.format.cli() })
+          ],
+        });
+      }
+
+      return instance;
+    },
+  };
+})();

--- a/packages/proxy/src/logger.ts
+++ b/packages/proxy/src/logger.ts
@@ -10,7 +10,7 @@ export const Logger = (function () {
           format: winston.format.json(),
           transports: [
             // TODO: Consider file transport for logging network activity
-            new winston.transports.Console({ format: winston.format.cli() })
+            new winston.transports.Console({ format: winston.format.cli() }),
           ],
         });
       }

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -4,12 +4,13 @@ import { ProxyInitializationOptions, CreateProxyOptions } from "./types.js";
 import { prepareSystem, ensureCACertificate } from "./system.js";
 import { pacFilterFunction } from "./utils.js";
 import chalk from "chalk";
-import { LOG_PREFIX } from "./constants.js";
+import { Logger } from "./logger.js";
 
 export async function create({ port: proxyPort }: CreateProxyOptions) {
   const startTime = performance.now();
   const httpsOpts = await ensureCACertificate();
   const server = getLocal({ https: httpsOpts });
+  const logger = Logger.getLogger();
   let isServerRunning = false;
 
   return async function start(config: ProxyInitializationOptions): Promise<Mockttp> {
@@ -77,11 +78,9 @@ export async function create({ port: proxyPort }: CreateProxyOptions) {
     });
 
     const startUpTimeInMs = Math.round(performance.now() - startTime);
-    console.log(`${LOG_PREFIX} - ${chalk.green(`Ready (${startUpTimeInMs}ms) and Willing to Serve!`)} `);
-
-    console.log(`
-🌐 Proxy: ${chalk.green(`https://localhost:${proxyPort}`)}
-📄 Proxy pac: ${chalk.green(`https://localhost:${proxyPort}/proxy.pac`)}`);
+    logger.info(chalk.green(`Ready (${startUpTimeInMs}ms) and Willing to Serve!`));
+    logger.info(`🌐 Proxy: ${chalk.green(`https://localhost:${proxyPort}`)}`);
+    logger.info(`📄 Proxy pac: ${chalk.green(`https://localhost:${proxyPort}/proxy.pac`)}`);
 
     return server;
   };

--- a/packages/proxy/src/utils.ts
+++ b/packages/proxy/src/utils.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from "fs";
 import { createHash } from "crypto";
 import { ProxyConfig } from "./types.js";
+import { Logger } from "./logger.js";
 
 /** Helper function to define a malcolm config */
 export function defineConfig<ContextT>(config: ProxyConfig<ContextT>) {
@@ -43,6 +44,7 @@ function createDeferred() {
 export function createFileWatcher(filePath: string, onChange: () => void) {
   const ac = new AbortController();
   const { promise, resolve } = createDeferred();
+  const logger = Logger.getLogger();
   (async () => {
     try {
       const configWatcher = fs.watch(filePath, { signal: ac.signal });
@@ -58,7 +60,7 @@ export function createFileWatcher(filePath: string, onChange: () => void) {
       }
     } catch (err: unknown) {
       if (err instanceof Error && err.name === "AbortError") {
-        console.log("Stopped file watcher");
+        logger.info("Stopped file watcher");
         resolve();
       }
     }
@@ -66,7 +68,7 @@ export function createFileWatcher(filePath: string, onChange: () => void) {
 
   return () => {
     ac.abort();
-    console.log("🛑 Stopped the file watcher");
+    logger.info("🛑 Stopped the file watcher");
 
     return promise;
   };


### PR DESCRIPTION
This PR adds the `winston` logger to Malcolm. For now, it only logs to the terminal, but we should add file loggers for network traffic and errors for improved debugging.

I chose `winston` instead of `pino` because `pino` appears to queue up logs which can be displayed out of order. For example, logs describing sudo prompt input would be displayed after the password prompt.

-----

Explicit list of changes:
- ℹ️ added note in README about not using `turbo` for running malcolm
- 🆕 added `winston` for logging
- 🆕 created `Logger` "instance" which mimics singleton pattern
    - 🤩 switched all `console.log` statements to `logger.info`