### PR TITLE
[fix]: Add .npmignore to ensure files are packed correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 proxy.config.ts
 .turbo
 tsconfig.tsbuildinfo
+*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+.turbo
+node_modules
+src
+tsconfig.tsbuildinfo
+*.config.*
+*.tgz
+tsconfig.json

--- a/packages/contrib/tsconfig.json
+++ b/packages/contrib/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "lib": ["ESNext"],
+    "rootDir": "src",
     "outDir": "./dist",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",


### PR DESCRIPTION
Fixes #33 by adding a `.npmignore` file.

By default, the [files](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#files) attribute in a package.json file will respect the `.gitignore` file if no `.npmignore` file is specified. This results in the `dist` directory being ignored which is problematic for consumers of `@nickhudkins/malcolm` since those files are necessary.

| Before | After |
| --- | --- |
| <img width="448" alt="image" src="https://github.com/user-attachments/assets/3151b659-5993-44ca-a942-5454ce5b1f79" /> | <img width="430" alt="image" src="https://github.com/user-attachments/assets/2682363d-b85a-467f-9910-1ce8c0dded2b" /> |